### PR TITLE
Metrics SameViewName

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -95,10 +95,14 @@ angular.module('starter', ['ionic', 'starter.controllers', 'starter.services'])
     }
   })
 
-  .state('week-metrics', {
+  .state('tab.week-metrics', {
     url: '/week-metrics',
-    templateUrl: 'templates/tab-week-metrics.html',
-    controller: 'WeekMetricsCtrl'
+    views: {
+      'tab-metrics': {
+        templateUrl: 'templates/tab-week-metrics.html',
+        controller: 'WeekMetricsCtrl'
+      }
+    }
   })
 
   .state('tab.contacts', {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -105,6 +105,16 @@ angular.module('starter', ['ionic', 'starter.controllers', 'starter.services'])
     }
   })
 
+  .state('tab.month-metrics', {
+    url: '/month-metrics',
+    views: {
+      'tab-metrics': {
+        templateUrl: 'templates/tab-month-metrics.html',
+        controller: 'MonthMetricsCtrl'
+      }
+    }
+  })
+
   .state('tab.contacts', {
     url: '/contacts',
     views: {

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -319,6 +319,10 @@ angular.module('starter.controllers', [])
     $state.go('tab.week-metrics');
   };
 
+  $scope.goToMonth = function() {
+    $state.go('tab.month-metrics');
+  };
+
   $scope.getMetrics = function() {
     // Logged in, calculate metrics for selected date
     $scope.numberTasks = 0;
@@ -386,6 +390,10 @@ angular.module('starter.controllers', [])
     $state.go('tab.metrics');
   };
 
+  $scope.goToMonth = function() {
+    $state.go('tab.month-metrics');
+  };
+
   $scope.getMetrics = function() {
     // Logged in, calculate metrics for selected date
     $scope.numberTasks = 0;
@@ -395,6 +403,83 @@ angular.module('starter.controllers', [])
     $scope.totalTime = 0;
 
     for (var i = 0; i < 7; i++) {
+      var date = new Date();
+      var dateTime = $scope.todayDate.getTime();
+      dateTime = dateTime - (i * 86400000);
+      date.setTime(dateTime);
+      var day = $rootScope.schedule.getDay(date);
+
+      day.items.forEach(function (item) {
+        if (item.duration > 0) {
+          // Event
+          $scope.numberEvents += 1;
+          $scope.totalTime += item.duration;
+          $scope.items.push({
+            name: item.name,
+            time: item.duration,
+            isEvent: true
+          })
+        } else {
+          // Task
+          $scope.numberTasks += 1;
+          if (item.isCompleted()) $scope.numberCompleted += 1;
+          $scope.totalTime += item.timeSpent;
+          $scope.items.push({
+            name: item.name,
+            time: item.timeSpent,
+            isEvent: false
+          })
+        }
+      })
+    }
+  }
+})
+
+.controller('MonthMetricsCtrl', function($scope, $ionicLoading, $state, $rootScope) {
+  $scope.$on('$ionicView.enter', function(e) {
+    if (firebase.auth().currentUser == null) {
+      // Require user to login
+      $ionicLoading.show({
+        template: 'Please log in',
+        noBackdrop: true,
+        duration: 1000
+      });
+      $state.go('login');
+    } else {
+      $scope.todayDate = new Date();
+      $scope.todayDate.setHours(0, 0, 0, 0);
+      $scope.getMetrics();
+    }
+  });
+
+  $scope.getColor = function(item) {
+    if (item.isEvent) return "hotpink";
+    return "blue";
+  };
+
+  $scope.getWidth = function(item) {
+    var percent = (item.time / $scope.totalTime) * 100;
+    var result = percent.toString() + "vw";
+    return result;
+  };
+
+  $scope.goToDay = function() {
+    $state.go('tab.metrics');
+  };
+
+  $scope.goToWeek = function() {
+    $state.go('tab.week-metrics');
+  };
+
+  $scope.getMetrics = function() {
+    // Logged in, calculate metrics for selected date
+    $scope.numberTasks = 0;
+    $scope.numberCompleted = 0;
+    $scope.numberEvents = 0;
+    $scope.items = [];
+    $scope.totalTime = 0;
+
+    for (var i = 0; i < 30; i++) {
       var date = new Date();
       var dateTime = $scope.todayDate.getTime();
       dateTime = dateTime - (i * 86400000);

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -316,7 +316,7 @@ angular.module('starter.controllers', [])
   };
 
   $scope.goToWeek = function() {
-    $state.go('week-metrics');
+    $state.go('tab.week-metrics');
   };
 
   $scope.getMetrics = function() {

--- a/www/templates/tab-metrics.html
+++ b/www/templates/tab-metrics.html
@@ -1,4 +1,4 @@
-<ion-view view-title="Done!">
+<ion-view view-title="Done!" hide-back-button="true">
   <ion-header-bar class="bar bar-subheader">
     <button class="button button-icon" ng-click="goToMonth()">
       <i class="icon ion-chevron-left"></i>

--- a/www/templates/tab-month-metrics.html
+++ b/www/templates/tab-month-metrics.html
@@ -1,16 +1,16 @@
 <ion-view view-title="Done!">
   <ion-header-bar class="bar bar-subheader">
-    <button class="button button-icon" ng-click="goToMonth()">
+    <button class="button button-icon" ng-click="goToWeek()">
       <i class="icon ion-chevron-left"></i>
     </button>
     <h2 class="title">Metrics</h2>
-    <button class="button button-icon" ng-click="goToWeek()">
+    <button class="button button-icon" ng-click="goToDay()">
       <i class="icon ion-chevron-right"></i>
     </button>
   </ion-header-bar>
   <ion-content class="padding">
     <div class="padding item item-divider">
-      Daily Stats for: <input type="date" ng-model="$parent.selectedDate" ng-blur="getMetrics()">
+      Stats for the past 30 days:
     </div>
     <div>
       <strong>Tasks completed: </strong>{{$parent.numberCompleted}} / {{$parent.numberTasks}}<br>

--- a/www/templates/tab-month-metrics.html
+++ b/www/templates/tab-month-metrics.html
@@ -1,4 +1,4 @@
-<ion-view view-title="Done!">
+<ion-view view-title="Done!" hide-back-button="true">
   <ion-header-bar class="bar bar-subheader">
     <button class="button button-icon" ng-click="goToWeek()">
       <i class="icon ion-chevron-left"></i>

--- a/www/templates/tab-week-metrics.html
+++ b/www/templates/tab-week-metrics.html
@@ -1,4 +1,4 @@
-<ion-view view-title="Done!">
+<ion-view view-title="Done!" hide-back-button="true">
   <ion-header-bar class="bar bar-subheader">
     <button class="button button-icon" ng-click="goToDay()">
       <i class="icon ion-chevron-left"></i>

--- a/www/templates/tab-week-metrics.html
+++ b/www/templates/tab-week-metrics.html
@@ -4,6 +4,9 @@
       <i class="icon ion-chevron-left"></i>
     </button>
     <h2 class="title">Metrics</h2>
+    <button class="button button-icon" ng-click="goToMonth()">
+      <i class="icon ion-chevron-right"></i>
+    </button>
   </ion-header-bar>
   <ion-content class="padding">
     <div class="padding item item-divider">


### PR DESCRIPTION
Previously, Ionic would automatically add a back button as the user
switched between the different metric views, which looked bad and was
unnecessary.

Now, the back button is hidden.